### PR TITLE
Fix focus interactions on mobile devices

### DIFF
--- a/client/src/components/Terminal.ts
+++ b/client/src/components/Terminal.ts
@@ -110,11 +110,14 @@ export const Terminal = () => {
     scrollToBottom()
   })
 
-  window.addEventListener("click", event => {
+  const onApplicationFocused = (event: MouseEvent | TouchEvent) => {
     if (["HTML", "BODY"].includes((event.target as HTMLElement).nodeName)) {
       input.focus()
     }
-  })
+  }
+
+  window.addEventListener("click", onApplicationFocused)
+  window.addEventListener("touchstart", onApplicationFocused)
 
   commandEmitter.on(LOG_EVENT, (...log: (string | Node)[]) => {
     container.insertBefore(

--- a/client/src/components/Terminal.ts
+++ b/client/src/components/Terminal.ts
@@ -111,13 +111,11 @@ export const Terminal = () => {
   })
 
   const onApplicationFocused = (event: MouseEvent | TouchEvent) => {
-    window.addEventListener("click", event => {
-      if (
-        ["HTML", "BODY"].includes((event.target as HTMLElement).nodeName) || 
-        (event.target as HTMLElement).id === container.id
-      ) {
-        input.focus()
-      }
+    if (
+      ["HTML", "BODY"].includes((event.target as HTMLElement).nodeName) || 
+      (event.target as HTMLElement).id === container.id
+    ) {
+      input.focus()
     }
   }
 


### PR DESCRIPTION
Mobile devices use the event name `touchstart` instead of `click`.

https://developer.mozilla.org/en-US/docs/Web/Events/touchstart